### PR TITLE
fix: add audio player to episodes 050-054 and patch sync script

### DIFF
--- a/_posts/2026-02-19-050.md
+++ b/_posts/2026-02-19-050.md
@@ -3,6 +3,7 @@ layout: podcast_post
 title: "#050 Produktmanagement trifft AI - mit Markus Andrezak (überproduct)"
 tags:
 episode: 50
+episode_url: "https://api.riverside.com/hosting-analytics/media/3404572013ad1d2897f5da0c7593bc3ebb797a5dcf1d5ccdd25856f7135dc7f7/eyJlcGlzb2RlSWQiOiI4MWFjOTdlNy0wZTU4LTQ2MTQtOGYzNS0xNGE3ODRhOWY0MDUiLCJwb2RjYXN0SWQiOiIwNWU2YWFhMC0wZTRiLTRjMTktOWRlMS0zNTI5NTQ5OTA0ZWUiLCJhY2NvdW50SWQiOiI2OTZhYThiNWNjZDI2MTRlYzk3MDQ2ZTciLCJwYXRoIjoibWVkaWEvY2xpcHMvNjk5MWE2MWVmMjM5ZDAwMzAzZWE4ZTBiL2FuZHItbmV1YmF1ZXJzLXN0dWRpby1jb21wb3Nlci0yMDI2LTItMTVfXzExLTU1LTI1Lm1wMyJ9.mp3"
 ---
 
 Nach einem eher technischen Blick in den letzten Folgen wechseln wir in dieser Episode auf die Produktseite. Dazu haben wir uns Markus Andrezak eingeladen, einen der bekanntesten Produkt-Coaches im Deutschsprachigen Raum.

--- a/_posts/2026-03-02-051.md
+++ b/_posts/2026-03-02-051.md
@@ -3,6 +3,7 @@ layout: podcast_post
 title: "#051 Agentic Engineering in der \"Praxis\" - mit Stefan Schubert-Peters (felmo)"
 tags:
 episode: 51
+episode_url: "https://api.riverside.com/hosting-analytics/media/1c89a9cbeab7b3e4661cb9998af0588e6eab377767e3e40b534b14d4336ebb1b/eyJlcGlzb2RlSWQiOiIxYTlhYjU5Ni1iOWEwLTQ2MDctYTdmZS05YzA1ZTdkMzg0OWMiLCJwb2RjYXN0SWQiOiIwNWU2YWFhMC0wZTRiLTRjMTktOWRlMS0zNTI5NTQ5OTA0ZWUiLCJhY2NvdW50SWQiOiI2OTZhYThiNWNjZDI2MTRlYzk3MDQ2ZTciLCJwYXRoIjoibWVkaWEvY2xpcHMvNjlhNTUxYTU0Yzk5YTIzMTY5ZDU2MGJiL2FuZHItbmV1YmF1ZXJzLXN0dWRpby1jb21wb3Nlci0yMDI2LTMtMl9fMTAtMC0yMS5tcDMifQ==.mp3"
 ---
 
 In dieser Episode sprechen wir mit Stefan Schubert-Peters, CPTO von felmo, über die Realität der KI-Adaption in einem wachsenden deutschen Startup. Stefan gibt uns tiefe Einblicke, wie felmo Technologie nutzt, um mobile Tierärzte zu unterstützen und die eigene Produktivität zu vervielfachen.

--- a/_posts/2026-03-05-052.md
+++ b/_posts/2026-03-05-052.md
@@ -3,6 +3,7 @@ layout: podcast_post
 title: "#052 Der „Elastic Loop“ und die Verwachsung mit der persönlichen KI - mit Robert Glaser (InnoQ)"
 tags:
 episode: 52
+episode_url: "https://api.riverside.com/hosting-analytics/media/bac69bc64fd75c44458ef8d60e4560b8cbdfd2be56b25f0269f7440340020720/eyJlcGlzb2RlSWQiOiI5MWY5Mzk0MS05YmZhLTQyOWQtYThlYi1jYzhlMGE1ZjhmM2IiLCJwb2RjYXN0SWQiOiIwNWU2YWFhMC0wZTRiLTRjMTktOWRlMS0zNTI5NTQ5OTA0ZWUiLCJhY2NvdW50SWQiOiI2OTZhYThiNWNjZDI2MTRlYzk3MDQ2ZTciLCJwYXRoIjoibWVkaWEvY2xpcHMvNjlhODg4YmYyNTNlODRkZGY2MmUyZTZjL2FuZHItbmV1YmF1ZXJzLXN0dWRpby1jb21wb3Nlci0yMDI2LTMtNF9fMjAtMzItMTQubXAzIn0=.mp3"
 ---
 
 In dieser Episode sprechen wir mit Robert Glaser, Head of Data & AI bei InnoQ, der uns tiefe Einblicke aus seiner Erfahrung mit der faszinierenden Welt der agentischen KI aus vielen Unternehmen gibt. Robert ist auch selbst ein "Power User", der die Technologie in seinem eigenen Alltag radikal testet.

--- a/_posts/2026-03-12-053.md
+++ b/_posts/2026-03-12-053.md
@@ -3,6 +3,7 @@ layout: podcast_post
 title: "#053 Agentic Coding in Production - mit Sebastian Sigl (Adevinta)"
 tags:
 episode: 53
+episode_url: "https://api.riverside.com/hosting-analytics/media/ecf35b235c3300be91929a4de7f1f38759a13ca72a298781684225f7756bc186/eyJlcGlzb2RlSWQiOiJmYThjOGRiMy1mNGU5LTQwZDItOTE5MC04YWZjYWI0ZDZmZjUiLCJwb2RjYXN0SWQiOiIwNWU2YWFhMC0wZTRiLTRjMTktOWRlMS0zNTI5NTQ5OTA0ZWUiLCJhY2NvdW50SWQiOiI2OTZhYThiNWNjZDI2MTRlYzk3MDQ2ZTciLCJwYXRoIjoibWVkaWEvY2xpcHMvNjliMTVlMWNhZjFmYTNmYWVlNzU2ZDE2L2FuZHItbmV1YmF1ZXJzLXN0dWRpby1jb21wb3Nlci0yMDI2LTMtMTFfXzEzLTIwLTQ0Lm1wMyJ9.mp3"
 ---
 
 In dieser Episode begrüßen wir Sebastian Sigl, Staff Engineer bei Adevinta (Kleinanzeigen), der uns zeigt, wie Agentic Coding in einer hochskalierbaren Produktionsumgebung (10.000+ Requests/Sekunde) Einzug hält. Sebastian ist ein erfahrener Fullstack-Entwickler, der den Wandel von einfacher Code-Completion hin zur echten Orchestrierung von KI-Agenten aktiv mitgestaltet.

--- a/_posts/2026-03-19-054.md
+++ b/_posts/2026-03-19-054.md
@@ -3,6 +3,7 @@ layout: podcast_post
 title: "#054 Was wir bisher gelernt haben und wohin die Reise geht."
 tags:
 episode: 54
+episode_url: "https://api.riverside.com/hosting-analytics/media/60959ec33bd6198d4bef0e568c54e96db0859ffc801fc74e83deeee2d3d8e8db/eyJlcGlzb2RlSWQiOiI0ZjdkZjk1MC04NjYxLTQ2ZWEtYmM0My01MDc5NGRhNzkwNDMiLCJwb2RjYXN0SWQiOiIwNWU2YWFhMC0wZTRiLTRjMTktOWRlMS0zNTI5NTQ5OTA0ZWUiLCJhY2NvdW50SWQiOiI2OTZhYThiNWNjZDI2MTRlYzk3MDQ2ZTciLCJwYXRoIjoibWVkaWEvY2xpcHMvNjliYjBiYWQ3MWNhMDkwZTBhM2E3ZWUxL2FuZHItbmV1YmF1ZXJzLXN0dWRpby1jb21wb3Nlci0yMDI2LTMtMThfXzIxLTMxLTQxLm1wMyJ9.mp3"
 ---
 
 In dieser Episode sprechen André Neubauer und Sebastian Heide-Meyer zu Erpen über die bisherigen Erkenntnisse, die Learnings aus einem Workshop, Team-Topologies und die Frage, warum gute Ergebnisse nicht aus Tooling allein entstehen.

--- a/scripts/sync-podcast.js
+++ b/scripts/sync-podcast.js
@@ -129,7 +129,18 @@ async function main() {
     const filepath = path.join(POSTS_DIR, filename);
 
     if (fs.existsSync(filepath)) {
-      console.log(`Exists, skipping: ${filename}`);
+      const existingContent = fs.readFileSync(filepath, "utf8");
+      if (!existingContent.includes("episode_url:") && episodeUrl) {
+        const patched = existingContent.replace(
+          /^(---[\s\S]*?)(---)/m,
+          (_, frontMatter, closing) =>
+            `${frontMatter}episode_url: ${JSON.stringify(episodeUrl)}\n${closing}`
+        );
+        fs.writeFileSync(filepath, patched, "utf8");
+        console.log(`Patched episode_url: ${filename}`);
+      } else {
+        console.log(`Exists, skipping: ${filename}`);
+      }
       continue;
     }
 


### PR DESCRIPTION
## Summary
- Added missing `episode_url` to episodes #050–#054 (fetched from Riverside RSS) so the audio player renders on their pages
- Patched `scripts/sync-podcast.js` to update existing files missing `episode_url` instead of silently skipping them — prevents recurrence

## Notes
- Episodes #047–#049 are still without `episode_url`: #047 is a teaser with no audio; #048 and #049 were not found in the Riverside RSS feed
- The sync script change is backwards-compatible: files that already have `episode_url` are still skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)