### PR TITLE
fix: remove decorative nav progress bar

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -16,18 +16,6 @@
     -->
     <nav class="site-nav" aria-label="Listen on">
 
-      <!--
-        Progress indicator: decorative "now playing" scrubber.
-        Static at 35% — requires JS + audio player integration to be functional.
-        Hidden on mobile (< 768px) via components.css media query.
-      -->
-      <div class="site-nav__progress" aria-hidden="true">
-        <div class="site-nav__progress-caret"></div>
-        <div class="site-nav__progress-track">
-          <div class="site-nav__progress-fill"></div>
-        </div>
-      </div>
-
       <div class="site-nav__pill">
         {% for platform in site.data.social %}
         <a class="social-icons__link"

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -48,51 +48,8 @@
 
 .site-nav {
   display: flex;
-  flex-direction: column;
   align-items: center;
-  gap: 0;
   position: relative;
-}
-
-/*
- * Progress indicator — decorative nav scrubber (Figma: thin 4px bar above the pill,
- * with a partial fill showing ~35% progress and a small caret above).
- * AMBIGUITY: This element has no defined interactive state in the Figma;
- * it appears to be a "now playing" audio progress indicator. Implemented
- * here as static/decorative. Requires JavaScript to become functional.
- */
-.site-nav__progress {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: var(--space-1);
-  margin-bottom: 6px;
-  pointer-events: none;
-}
-
-.site-nav__progress-caret {
-  width: 0;
-  height: 0;
-  border-left: 5px solid transparent;
-  border-right: 5px solid transparent;
-  border-top: 6px solid var(--color-track-active);
-}
-
-.site-nav__progress-track {
-  width: 280px;
-  height: var(--space-1);       /* 4px */
-  background: var(--color-track-inactive);
-  border-radius: var(--radius-track);
-  overflow: hidden;
-  position: relative;
-}
-
-.site-nav__progress-fill {
-  position: absolute;
-  inset: 0 auto 0 0;
-  width: 35%;                   /* static placeholder; JS will drive this */
-  background: var(--color-track-active);
-  border-radius: var(--radius-track);
 }
 
 /* The social pill */
@@ -106,18 +63,6 @@
   padding: var(--space-3) clamp(var(--space-3), 4.2vw, var(--space-8));
 }
 
-/* Responsive: hide progress bar on mobile to save space */
-@media (max-width: 767px) {
-  .site-nav__progress {
-    display: none;
-  }
-}
-
-@media (min-width: 1280px) {
-  .site-nav__progress-track {
-    width: 476px;   /* exact Figma width at desktop */
-  }
-}
 
 
 /* ------------------------------------------------------------------

--- a/assets/css/tokens.css
+++ b/assets/css/tokens.css
@@ -42,8 +42,7 @@
   --color-text-secondary:  var(--color-gray-mid);   /* labels, meta, placeholders   */
   --color-text-on-cta:     var(--color-white-warm); /* text inside filled CTA btn   */
   --color-bg-cta:          var(--color-gray-mid);   /* filled CTA button background */
-  --color-track-inactive:  var(--color-gray-light); /* progress-bar unfilled track  */
-  --color-track-active:    var(--color-gray-mid);   /* progress-bar filled portion  */
+  --color-track-inactive:  var(--color-gray-light); /* divider lines, track fills   */
 
 
   /* ===================================================================
@@ -115,7 +114,6 @@
 
   --radius-artwork:  30px;    /* episode cover / album art images    */
   --radius-card:     60px;    /* episode list cards, footer panel    */
-  --radius-track:   100px;    /* progress bar pill                   */
   --radius-pill:   1000px;    /* nav social-links pill (full-pill)   */
 
 


### PR DESCRIPTION
## Summary
- Removed the decorative "now playing" progress bar/caret rendered above the social-icon nav pill, which had no functionality and showed up as a stray horizontal line in the header.
- Cleaned up the now-unused `.site-nav__progress*` CSS rules and related `--color-track-active` / `--radius-track` design tokens.

## Test plan
- [x] `bundle exec jekyll build` succeeds
- [x] Verified in dev server (desktop + mobile) that the bar is gone and the social pill remains correctly centered