### PR TITLE
Limit homepage accordion to 6 most recent episodes

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -107,9 +107,12 @@ layout: default
        ═══════════════════════════════════════════════════════════ -->
   <section class="home-accordion">
     <div class="accordion" data-accordion>
+      {% assign accordion_count = 0 %}
       {% for post in site.posts %}
         {% if post.url == latest.url %}{% continue %}{% endif %}
         {% if post.episode >= 47 %}
+          {% if accordion_count >= 6 %}{% break %}{% endif %}
+          {% assign accordion_count = accordion_count | plus: 1 %}
 
           {% assign title_parts = post.title | split: " " %}
           {% assign episode_title = title_parts | slice: 1, 99 | join: " " %}


### PR DESCRIPTION
## Summary
- Caps the homepage episode accordion to the 6 most recent eligible episodes (in addition to the latest episode shown above it), rather than listing all episodes from #47 onward.

## Test plan
- [x] Started local Jekyll dev server and confirmed the accordion renders 6 entries