### PR TITLE
Mobile responsive QA fixes for the redesign

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 _site
 .jekyll-metadata
 redesign
+scripts/node_modules
+scripts/screenshots
+scripts/package*.json

--- a/_config.yml
+++ b/_config.yml
@@ -1,11 +1,11 @@
 website_url: /
 title: HMZE
-description: Beyond Vibe Coding - der Podcast über die Zukunft der Softwareentwicklung
+description: Beyond Vibe Coding - the podcast about the future of software development
 feed_url: feed/
-feed_lang: de
+feed_lang: en
 feed_since: Fri, 05 Feb 2021 00:00 +0000
 logo: /assets/img/logo.jpeg
-feed_owner: Sebastian Heide-Meyer zu Erpen und André Neubauer
+feed_owner: Sebastian Heide-Meyer zu Erpen and André Neubauer
 feed_contact: podcast@hmze.tech
 
 color-scheme: dark

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -70,7 +70,7 @@ layout: default
         <h2 class="episode-card__title">
           <a href="{{ latest.url | relative_url }}">{{ latest.title }}</a>
         </h2>
-        <p class="episode-card__date">{{ latest.date | date: "%-d. %B %Y" }}</p>
+        <p class="episode-card__date">{{ latest.date | date: "%B %-d, %Y" }}</p>
         {% if latest.episode_url %}
         <audio class="episode-card__audio" controls preload="none">
           <source src="{{ latest.episode_url }}" type="audio/mpeg">

--- a/_layouts/podcast_post.md
+++ b/_layouts/podcast_post.md
@@ -19,7 +19,7 @@ layout: default
     {% endif %}
     <div class="post-hero__meta">
       <h1 class="post-hero__title">{{ page.title }}</h1>
-      <p class="post-hero__date">{{ page.date | date: "%-d. %B %Y" }}</p>
+      <p class="post-hero__date">{{ page.date | date: "%B %-d, %Y" }}</p>
     </div>
   </section>
 
@@ -63,26 +63,26 @@ layout: default
          page.previous = chronologically OLDER post
          page.next     = chronologically NEWER post
        ══════════════════════════════════════════════════ -->
-  <nav class="post-nav" aria-label="Episoden Navigation">
+  <nav class="post-nav" aria-label="Episode navigation">
     <div class="post-nav__older">
       {% if page.previous %}
       <a class="post-nav__link" href="{{ page.previous.url | relative_url }}">
         <span class="post-nav__arrow" aria-hidden="true">←</span>
         <span class="post-nav__info">
-          <span class="post-nav__label">Ältere Folge</span>
+          <span class="post-nav__label">Older episode</span>
           <span class="post-nav__title">{{ page.previous.title }}</span>
         </span>
       </a>
       {% endif %}
     </div>
     <div class="post-nav__home">
-      <a class="btn-cta" href="{{ '/' | relative_url }}">Alle Folgen</a>
+      <a class="btn-cta" href="{{ '/' | relative_url }}">All episodes</a>
     </div>
     <div class="post-nav__newer">
       {% if page.next %}
       <a class="post-nav__link post-nav__link--right" href="{{ page.next.url | relative_url }}">
         <span class="post-nav__info">
-          <span class="post-nav__label">Neuere Folge</span>
+          <span class="post-nav__label">Newer episode</span>
           <span class="post-nav__title">{{ page.next.title }}</span>
         </span>
         <span class="post-nav__arrow" aria-hidden="true">→</span>

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -284,7 +284,9 @@
   grid-template-columns: 1fr;
   align-items: center;
   justify-items: center;
-  gap: var(--space-8);
+  /* Mobile: paragraphs sit close under the lockup (Figma mobile frame);
+     desktop spacing comes from the pinned-lockup layout below. */
+  gap: var(--space-4);
 }
 
 @media (min-width: 1024px) {
@@ -388,15 +390,27 @@
   line-height: var(--line-height-body);
   color: var(--color-text-secondary);
   max-width: 600px;
-  margin: var(--space-8) auto 0;
+  margin: var(--space-4) auto 0;
 }
 
-/* Platform button — icon + label in a pill */
+@media (min-width: 1024px) {
+  .home-hero__intro {
+    margin-top: var(--space-8);
+  }
+}
+
+/* Platform button — icon + label in a pill.
+   Mobile: icon-only round buttons in a single horizontal row (Figma
+   mobile shows an icon row without labels); each link keeps its
+   aria-label and a 44px touch box. Labels return at tablet+. */
 .platform-btn {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: var(--space-2);
-  padding: var(--space-2) var(--space-3);
+  padding: var(--space-2);
+  min-width: 44px;
+  min-height: 44px;
   background: var(--color-surface-card);
   border-radius: var(--radius-pill);
   box-shadow: var(--shadow-cta);
@@ -406,6 +420,22 @@
   color: var(--color-text-primary);
   transition: opacity 0.15s ease;
   white-space: nowrap;
+}
+
+.platform-btn span {
+  display: none;
+}
+
+@media (min-width: 768px) {
+  .platform-btn {
+    padding: var(--space-2) var(--space-3);
+    min-width: 0;
+    min-height: 0;
+  }
+
+  .platform-btn span {
+    display: inline;
+  }
 }
 
 .platform-btn:hover {

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -350,7 +350,12 @@
    the nav bar) so the gradient line starts at the very top. */
 .hero-lockup {
   width: min(100%, 420px);
-  aspect-ratio: 538 / 787;
+  /* The SVG is portrait (538×787); the top half is the long accent-line
+     gradient meant to run down from the page top on desktop. On mobile
+     the lockup sits in normal flow, so crop to the bracket/wordmark
+     portion plus a short stub of the line — same treatment as the
+     footer lockup. */
+  aspect-ratio: 538 / 550;
 }
 
 @media (min-width: 1024px) {
@@ -360,6 +365,7 @@
     left: 50%;
     transform: translateX(-50%);
     z-index: 0;
+    aspect-ratio: 538 / 787;   /* full asset incl. accent line */
   }
 }
 
@@ -367,6 +373,8 @@
   display: block;
   width: 100%;
   height: 100%;
+  object-fit: cover;
+  object-position: center bottom;
 }
 
 /* Full-width intro paragraph below the lockup */
@@ -778,7 +786,7 @@
 .post-hero {
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
+  align-items: center;
   gap: var(--space-5);
   margin-bottom: var(--space-6);
 }
@@ -792,12 +800,25 @@
 
 .post-hero__artwork {
   flex-shrink: 0;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+
+@media (min-width: 768px) {
+  .post-hero__artwork {
+    width: auto;
+  }
 }
 
 .post-hero__cover {
   display: block;
-  width: 180px;
-  height: 180px;
+  /* Mobile: the artwork is the page's hero visual — span the content
+     column (Figma mobile shows it near full-bleed); cap at the same
+     420px the hero lockup uses. */
+  width: min(100%, 420px);
+  height: auto;
+  aspect-ratio: 1 / 1;
   object-fit: cover;
   border-radius: var(--radius-artwork);
   box-shadow: var(--shadow-artwork-lg);

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -18,8 +18,12 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: var(--space-5);    /* 36px */
-  height: var(--space-5);
+  /* 48px hit area for the 44px WCAG touch-target minimum; negative
+     margin keeps the 36px layout footprint so the nav pill and footer
+     row don't grow. Icon itself stays 36px (set on the img below). */
+  width: var(--space-6);
+  height: var(--space-6);
+  margin: calc((var(--space-5) - var(--space-6)) / 2);
   flex-shrink: 0;
   transition: opacity 0.15s ease;
 }
@@ -30,8 +34,8 @@
 }
 
 .social-icons__link img {
-  width: 100%;
-  height: 100%;
+  width: var(--space-5);    /* 36px visual size, independent of hit area */
+  height: var(--space-5);
   object-fit: contain;
   filter: grayscale(100%) opacity(60%);
   transition: filter 0.15s ease;
@@ -159,7 +163,9 @@
   grid-area: nav;
   display: flex;
   flex-direction: column;
-  gap: var(--space-2);    /* 10px */
+  /* Links carry 10px block padding for the 44px touch target, which
+     supplies the visual rhythm — no extra gap needed. */
+  gap: 0;
   align-items: flex-start;
 }
 
@@ -175,6 +181,8 @@
   font-size: var(--font-size-sm);     /* 16px */
   line-height: var(--line-height-body);
   color: var(--color-text-secondary);
+  /* 24px line-height + 2×10px padding = 44px touch target */
+  padding-block: var(--space-2);
 }
 
 .site-footer__nav-link:hover,
@@ -356,6 +364,9 @@
      portion plus a short stub of the line — same treatment as the
      footer lockup. */
   aspect-ratio: 538 / 550;
+  /* Mobile stack order per the Figma mobile frame: lockup first,
+     then the copy paragraphs. */
+  order: -1;
 }
 
 @media (min-width: 1024px) {
@@ -366,6 +377,7 @@
     transform: translateX(-50%);
     z-index: 0;
     aspect-ratio: 538 / 787;   /* full asset incl. accent line */
+    order: 0;
   }
 }
 
@@ -460,8 +472,12 @@
 }
 
 .episode-card__cover {
-  width: 200px;
-  height: 200px;
+  /* Mobile: artwork is the card's hero visual — span the card's inner
+     width (Figma mobile shows it near full-bleed), capped at the
+     tablet+ fixed size. */
+  width: min(100%, 280px);
+  height: auto;
+  aspect-ratio: 1 / 1;
   object-fit: cover;
   border-radius: var(--radius-artwork);
   box-shadow: var(--shadow-artwork-lg);
@@ -486,9 +502,17 @@
 .episode-card__title {
   font-family: var(--font-family-sans);
   font-weight: var(--font-weight-light);
-  font-size: var(--font-size-lg);
+  /* Mobile: one step down the type scale — 32px wraps the long episode
+     titles to 5+ lines on a 390px viewport. */
+  font-size: var(--font-size-md);
   line-height: var(--line-height-normal);
   color: var(--color-text-primary);
+}
+
+@media (min-width: 768px) {
+  .episode-card__title {
+    font-size: var(--font-size-lg);
+  }
 }
 
 .episode-card__title a {
@@ -661,6 +685,10 @@
   color: var(--color-text-primary);
   text-decoration: underline;
   align-self: flex-start;
+  /* 24px line-height + 2×10px padding = 44px touch target; negative
+     margin keeps the surrounding flex-column rhythm unchanged. */
+  padding-block: var(--space-2);
+  margin-block: calc(-1 * var(--space-2));
 }
 
 .accordion__meta {
@@ -675,10 +703,19 @@
 .accordion__controls {
   display: flex;
   align-items: center;
-  gap: var(--space-3);
+  gap: var(--space-2);
   font-size: var(--font-size-md);
   line-height: 1;
   color: var(--color-text-secondary);
+}
+
+.accordion__control {
+  /* 44px is the WCAG touch-target minimum, not a design token */
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 44px;
+  min-height: 44px;
 }
 
 .accordion__control:hover {
@@ -689,7 +726,16 @@
 .accordion__platforms {
   display: flex;
   align-items: center;
-  gap: var(--space-3);
+  gap: var(--space-2);
+}
+
+.accordion__platform {
+  /* 44px is the WCAG touch-target minimum, not a design token */
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 44px;
+  min-height: 44px;
 }
 
 .accordion__platform img {
@@ -836,14 +882,33 @@
   flex-direction: column;
   gap: var(--space-2);
   min-width: 0;  /* allow flex child to shrink below content width */
+  /* Mobile: meta is stacked under the centered artwork — center it too
+     (Figma mobile shows the title centered). */
+  text-align: center;
+  align-items: center;
+}
+
+@media (min-width: 768px) {
+  .post-hero__meta {
+    text-align: left;
+    align-items: flex-start;
+  }
 }
 
 .post-hero__title {
   font-family: var(--font-family-sans);
   font-weight: var(--font-weight-light);
-  font-size: var(--font-size-lg);
+  /* Mobile: one step down the type scale — 32px wraps the long episode
+     titles to 6 lines on a 390px viewport. */
+  font-size: var(--font-size-md);
   line-height: var(--line-height-normal);
   color: var(--color-text-primary);
+}
+
+@media (min-width: 768px) {
+  .post-hero__title {
+    font-size: var(--font-size-lg);
+  }
 }
 
 .post-hero__date {
@@ -874,6 +939,15 @@
   display: flex;
   flex-wrap: wrap;
   gap: var(--space-2);
+  /* Mobile: buttons wrap under the centered hero — center the row
+     (Figma mobile shows the platform links centered). */
+  justify-content: center;
+}
+
+@media (min-width: 768px) {
+  .post-player__platforms {
+    justify-content: flex-start;
+  }
 }
 
 

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -545,6 +545,15 @@
   color: var(--color-text-primary);
 }
 
+/* Mobile: the CTA hugs its label and centers under the stacked card
+   (Figma mobile); on tablet+ it stretches with the body column, which
+   is the established desktop appearance. */
+@media (max-width: 767px) {
+  .episode-card--featured .btn-cta {
+    align-self: center;
+  }
+}
+
 
 /* ------------------------------------------------------------------
    Episode accordion (home page) — <details>/<summary> rows.
@@ -1108,7 +1117,9 @@
 .post-nav__label {
   font-family: var(--font-family-mono);
   font-weight: var(--font-weight-regular);
-  font-size: var(--font-size-xs);
+  /* sm, not xs: 11px is below the 14px legibility floor for
+     functional text (xs is reserved for the wordmark graphic) */
+  font-size: var(--font-size-sm);
   color: var(--color-text-secondary);
 }
 

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -107,15 +107,6 @@
   height: auto;
 }
 
-/* Hide wordmark on very small screens to avoid crowding the nav */
-@media (max-width: 639px) {
-  .site-header__wordmark {
-    display: none;
-  }
-  .site-header__inner {
-    grid-template-columns: auto 1fr;
-  }
-}
 
 
 /* ------------------------------------------------------------------

--- a/assets/css/layout.css
+++ b/assets/css/layout.css
@@ -33,6 +33,8 @@
    ------------------------------------------------------------------ */
 
 .site-header {
+  /* Figma mobile frames have no header — pages open with the hero/episode label */
+  display: none;
   position: relative;
   z-index: 1;
   width: 100%;
@@ -40,6 +42,12 @@
   /* Approx 40px top padding based on logo y:61 from Figma */
   padding-top: clamp(1.25rem, 3.2vw, 2.5rem);
   padding-bottom: clamp(1rem, 2vw, 1.5rem);
+}
+
+@media (min-width: 640px) {
+  .site-header {
+    display: block;
+  }
 }
 
 .site-header__inner {

--- a/scripts/measure-mobile.js
+++ b/scripts/measure-mobile.js
@@ -1,0 +1,82 @@
+// Programmatic mobile QA measurements at iPhone 13 (390px).
+const { chromium, devices } = require('playwright');
+
+const BASE = 'http://localhost:4568';
+
+const SELECTORS = {
+  home: [
+    '.site-header', '.site-header__inner', '.site-header__logo img', '.site-nav__pill',
+    '.social-icons__link', '.hero-lockup', '.hero-lockup__image',
+    '.home-hero__copy--left', '.home-hero__copy--right', '.home-hero__intro',
+    '.episode-card--featured', '.episode-card__media', '.episode-card__cover',
+    '.episode-card__body', '.btn-cta',
+    '.accordion__item', '.accordion__summary', '.accordion__icon',
+    '.home-accordion__cta', '.site-footer__card', '.site-footer__nav-link',
+    '.site-footer__lockup img', '.site-footer__social .social-icons__link',
+  ],
+  post: [
+    '.site-header__inner', '.post-page', '.post-hero', '.post-hero__cover',
+    '.post-hero__title', '.post-player__audio', '.platform-btn',
+    '.post-prose', '.post-nav', '.post-nav__link', '.post-nav__home .btn-cta',
+  ],
+};
+
+(async () => {
+  const browser = await chromium.launch();
+  const context = await browser.newContext({ ...devices['iPhone 13'] });
+
+  for (const [name, url] of [['home', `${BASE}/`], ['post', `${BASE}/2026/06/11/001/`]]) {
+    const page = await context.newPage();
+    await page.goto(url, { waitUntil: 'networkidle' });
+    console.log(`\n===== ${name} (${url}) =====`);
+    for (const sel of SELECTORS[name]) {
+      const data = await page.evaluate((s) => {
+        const els = [...document.querySelectorAll(s)];
+        if (!els.length) return null;
+        const el = els[0];
+        const r = el.getBoundingClientRect();
+        const cs = getComputedStyle(el);
+        return {
+          count: els.length,
+          rect: { x: +r.x.toFixed(1), y: +r.y.toFixed(1), w: +r.width.toFixed(1), h: +r.height.toFixed(1) },
+          fontSize: cs.fontSize,
+          display: cs.display,
+          gridCols: cs.gridTemplateColumns,
+          flexDir: cs.flexDirection,
+          pad: cs.padding,
+          margin: cs.margin,
+        };
+      }, sel);
+      console.log(sel, JSON.stringify(data));
+    }
+    // Touch target audit: all interactive elements smaller than 44x44
+    const small = await page.evaluate(() => {
+      const out = [];
+      for (const el of document.querySelectorAll('a, button, summary, audio')) {
+        const r = el.getBoundingClientRect();
+        if (r.width === 0 || r.height === 0) continue;
+        if (r.width < 44 || r.height < 44) {
+          out.push(`${el.tagName.toLowerCase()}.${[...el.classList].join('.')} ${r.width.toFixed(0)}x${r.height.toFixed(0)}`);
+        }
+      }
+      return [...new Set(out)];
+    });
+    console.log('TOUCH<44px:', JSON.stringify(small, null, 1));
+    // Sub-14px text audit
+    const tiny = await page.evaluate(() => {
+      const out = new Set();
+      const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
+      while (walker.nextNode()) {
+        const n = walker.currentNode;
+        if (!n.textContent.trim()) continue;
+        const el = n.parentElement;
+        const fs = parseFloat(getComputedStyle(el).fontSize);
+        if (fs < 14) out.add(`${el.tagName.toLowerCase()}.${[...el.classList].join('.')} ${fs}px`);
+      }
+      return [...out];
+    });
+    console.log('FONT<14px:', JSON.stringify(tiny, null, 1));
+    await page.close();
+  }
+  await browser.close();
+})();

--- a/scripts/mobile-screenshots.js
+++ b/scripts/mobile-screenshots.js
@@ -1,0 +1,68 @@
+// Mobile visual QA captures with true device emulation (iPhone 13: 390x844, DPR 3, touch).
+// Usage: node mobile-screenshots.js [--desktop] [--width N [--height N]] [--suffix name]
+const { chromium, devices } = require('playwright');
+const path = require('path');
+
+const BASE = 'http://localhost:4568';
+const PAGES = [
+  { name: 'home', url: `${BASE}/` },
+  { name: 'post', url: `${BASE}/2026/06/11/001/` },
+];
+
+const args = process.argv.slice(2);
+const getArg = (flag) => {
+  const i = args.indexOf(flag);
+  return i !== -1 ? args[i + 1] : null;
+};
+
+(async () => {
+  const browser = await chromium.launch();
+
+  let contextOptions;
+  let prefix;
+  if (args.includes('--desktop')) {
+    contextOptions = { viewport: { width: 1440, height: 900 }, deviceScaleFactor: 2 };
+    prefix = 'desktop';
+  } else if (getArg('--width')) {
+    const width = parseInt(getArg('--width'), 10);
+    const height = parseInt(getArg('--height') || '812', 10);
+    contextOptions = {
+      viewport: { width, height },
+      deviceScaleFactor: 2,
+      isMobile: width < 768,
+      hasTouch: width < 1024,
+    };
+    prefix = `w${width}`;
+  } else {
+    contextOptions = { ...devices['iPhone 13'] };
+    prefix = 'mobile-impl';
+  }
+  const suffix = getArg('--suffix');
+  if (suffix) prefix = `${prefix}-${suffix}`;
+
+  const context = await browser.newContext(contextOptions);
+
+  for (const { name, url } of PAGES) {
+    const page = await context.newPage();
+    await page.goto(url, { waitUntil: 'networkidle' });
+    await page.evaluate(() => document.fonts.ready);
+    // Freeze animations/transitions for deterministic captures
+    await page.addStyleTag({
+      content: '*, *::before, *::after { animation: none !important; transition: none !important; }',
+    });
+    await page.waitForTimeout(300);
+    const file = path.join(__dirname, 'screenshots', `${prefix}-${name}.png`);
+    await page.screenshot({ path: file, fullPage: true });
+    const overflow = await page.evaluate(() => ({
+      scrollWidth: document.documentElement.scrollWidth,
+      clientWidth: document.documentElement.clientWidth,
+    }));
+    console.log(
+      `${file}  viewport=${contextOptions.viewport.width}px  scrollWidth=${overflow.scrollWidth}` +
+        (overflow.scrollWidth > overflow.clientWidth ? '  ⚠ HORIZONTAL OVERFLOW' : '')
+    );
+    await page.close();
+  }
+
+  await browser.close();
+})();


### PR DESCRIPTION
## What

Visual QA pass of the redesign against the Figma mobile frames (iPhone 13 / 390px device emulation), plus follow-up review findings. Six commits, grouped by concern:

### Responsive fixes (CSS only, mobile-first)
- **Hero lockup** (high): crop the 538×787 SVG to the bracket/wordmark portion on mobile (`aspect-ratio: 538/550` + `object-fit: cover`, same treatment as the footer lockup) instead of rendering ~210px of bare accent line; lockup now stacks first per the Figma frame.
- **Post hero** (high): episode artwork goes near full-width and centered on mobile (was fixed 180px, left-aligned); title/date centered at 24px, desktop layout restored at 768px.
- **Featured card** (mid): cover spans the card width on mobile; title 24px; CTA hugs its label and centers.
- **Touch targets** (mid): social icons, accordion controls, platform buttons, footer links and read-more links all get ≥44×44px hit areas (visual footprint unchanged via negative-margin technique).
- **Site header hidden below 640px** — the Figma mobile frames open directly with the hero/episode card, no logo + social pill header.
- **Hero copy spacing**: paragraph gaps under the lockup tightened from 80px to 24px on mobile.
- **Platform row on post page**: icon-only round buttons in one centered horizontal row on mobile (labels were forcing a vertical pill stack); labels return at 768px. `aria-label`s keep the links accessible.
- **Post-nav label** (low): 11px → 16px.

### Wording
- German UI strings replaced with English: "Ältere/Neuere Folge" → "Older/Newer episode", "Alle Folgen" → "All episodes", episode-nav `aria-label`.
- Date format `11. June 2026` → `June 11, 2026` (post hero + featured card).
- `_config.yml`: description translated, `feed_lang: de` → `en`, "und" → "and" in `feed_owner`. These only affect the site's own `/feed/`; the canonical podcast feed is the external Anchor.fm one. Older German-language episode *titles* in `_posts/` are content and were left untouched.

## Verification

- Playwright device-emulation captures (iPhone 13) for home + latest post after every fix group.
- Programmatic audits on both pages: no touch target <44px, no text <14px, no horizontal overflow at 390/639/640/767/768/1023/1024/1440px.
- Breakpoint boundary captures at 639/640, 767/768, 1023/1024: clean transitions, no broken intermediate states.
- Desktop 1440px pixel-diffed before/after: only intended changes (footer link spacing, date/label text); layout otherwise pixel-identical.

## Reviewer notes

Structural gaps vs. Figma that are out of scope for a CSS pass (need product decisions): no episode carousel on home, post page renders flat prose instead of the design's accordions, featured card lacks the platform icon row, native audio scrubber instead of the design's play glyph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)