### PR TITLE
Fix: show recent episodes on home page regardless of episode number

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -88,10 +88,12 @@ layout: default
   {% endif %}
 
   <!-- ═══════════════════════════════════════════════════════════
-       EPISODE LIST — accordion, episodes 47+ (47+ filter preserved
-       from the previous implementation; older episodes live in
-       the archive only).
-       Latest episode is skipped (already shown above).
+       EPISODE LIST — accordion showing the 6 most recent episodes.
+       The latest episode is skipped (already shown in the featured
+       card above); the full back-catalogue lives in the archive.
+       No episode-number filter: the 6-row cap already keeps the
+       list to recent episodes, and a restarted season means episode
+       numbers are no longer unique / monotonic.
        Figma reference: redesign/Beyond Vibe Coding - Website.png
        (Figma MCP unavailable this session — measured from the
        provided static export, not a live node inspection).
@@ -110,51 +112,49 @@ layout: default
       {% assign accordion_count = 0 %}
       {% for post in site.posts %}
         {% if post.url == latest.url %}{% continue %}{% endif %}
-        {% if post.episode >= 47 %}
-          {% if accordion_count >= 6 %}{% break %}{% endif %}
-          {% assign accordion_count = accordion_count | plus: 1 %}
+        {% if accordion_count >= 6 %}{% break %}{% endif %}
+        {% assign accordion_count = accordion_count | plus: 1 %}
 
-          {% assign title_parts = post.title | split: " " %}
-          {% assign episode_title = title_parts | slice: 1, 99 | join: " " %}
+        {% assign title_parts = post.title | split: " " %}
+        {% assign episode_title = title_parts | slice: 1, 99 | join: " " %}
 
-          <details class="accordion__item">
-            <summary class="accordion__summary">
-              <span class="accordion__label">S.01 EP.{{ post.episode }} - {{ episode_title }}</span>
-              <span class="accordion__icon" aria-hidden="true"></span>
-            </summary>
-            <div class="accordion__panel">
-              <div class="accordion__cover">
-                {% if post.cover_image %}
-                <img src="{{ post.cover_image }}" alt="" loading="lazy">
-                {% else %}
-                <div class="accordion__cover-placeholder" aria-hidden="true"></div>
-                {% endif %}
-              </div>
-              <div class="accordion__content">
-                <p class="accordion__desc">{{ post.content | strip_html | truncatewords: 50 }}</p>
-                <a class="accordion__readmore" href="{{ post.url | relative_url }}">Read more</a>
-                <div class="accordion__meta">
-                  <div class="accordion__controls">
-                    {% if post.episode_url %}
-                    <a class="accordion__control" href="{{ post.episode_url }}" aria-label="Play episode" target="_blank" rel="noopener noreferrer">▶</a>
-                    {% endif %}
-                    <a class="accordion__control" href="{{ post.url | relative_url }}" aria-label="Open episode page">↗</a>
-                  </div>
-                  <nav class="accordion__platforms" aria-label="Listen on">
-                    {% for platform in site.data.platforms %}
-                    {% unless platform.id == "rss" %}
-                    <a class="accordion__platform" href="{{ platform.url }}" aria-label="{{ platform.label }}" target="_blank" rel="noopener noreferrer">
-                      <img src="{{ platform.icon | relative_url }}" alt="" width="22" height="22">
-                    </a>
-                    {% endunless %}
-                    {% endfor %}
-                  </nav>
+        <details class="accordion__item">
+          <summary class="accordion__summary">
+            <span class="accordion__label">S.01 EP.{{ post.episode }} - {{ episode_title }}</span>
+            <span class="accordion__icon" aria-hidden="true"></span>
+          </summary>
+          <div class="accordion__panel">
+            <div class="accordion__cover">
+              {% if post.cover_image %}
+              <img src="{{ post.cover_image }}" alt="" loading="lazy">
+              {% else %}
+              <div class="accordion__cover-placeholder" aria-hidden="true"></div>
+              {% endif %}
+            </div>
+            <div class="accordion__content">
+              <p class="accordion__desc">{{ post.content | strip_html | truncatewords: 50 }}</p>
+              <a class="accordion__readmore" href="{{ post.url | relative_url }}">Read more</a>
+              <div class="accordion__meta">
+                <div class="accordion__controls">
+                  {% if post.episode_url %}
+                  <a class="accordion__control" href="{{ post.episode_url }}" aria-label="Play episode" target="_blank" rel="noopener noreferrer">▶</a>
+                  {% endif %}
+                  <a class="accordion__control" href="{{ post.url | relative_url }}" aria-label="Open episode page">↗</a>
                 </div>
+                <nav class="accordion__platforms" aria-label="Listen on">
+                  {% for platform in site.data.platforms %}
+                  {% unless platform.id == "rss" %}
+                  <a class="accordion__platform" href="{{ platform.url }}" aria-label="{{ platform.label }}" target="_blank" rel="noopener noreferrer">
+                    <img src="{{ platform.icon | relative_url }}" alt="" width="22" height="22">
+                  </a>
+                  {% endunless %}
+                  {% endfor %}
+                </nav>
               </div>
             </div>
-          </details>
+          </div>
+        </details>
 
-        {% endif %}
       {% endfor %}
     </div>
     <a class="btn-cta home-accordion__cta" href="{{ '/archive/' | relative_url }}">{view_more_episodes}</a>


### PR DESCRIPTION
## Problem

On https://bvc.fm the **second-to-last episode was missing** from the home page episode list, while https://bvc.fm/archive/ showed it correctly.

The podcast restarted episode numbering for a new season, so the two newest episodes (`#001 Reliable AI Agents – Csaba Tamas`, `#002 Fable Ban`) have low `episode` numbers. The home accordion in `_layouts/home.html` gated every row on `{% raw %}{% if post.episode >= 47 %}{% endraw %}` — a leftover proxy for hiding the 2021–2023 back-catalogue (episodes 1–46). So `#001` (`episode: 1`) was filtered out. The archive has no such filter, hence the discrepancy.

## Fix

Remove the episode-number filter from the home accordion loop. It is:

- **Redundant** — the accordion already caps at the **6 most recent** episodes (newest-first). There are 20+ posts dated 2026 ahead of the newest legacy post (`2023-07-11`), so a legacy episode can never reach the cap.
- **Unsafe now** — with numbering restarted, `episode` numbers are no longer unique (two posts have `episode: 1`), so any number-based filter is fundamentally broken.

## Verification

Built locally with the live `#002` post present:

- **Featured card:** `#002 Fable Ban` (newest)
- **List:** `EP.1 (Csaba Tamas)` → `EP.65 → EP.64 → EP.63 → EP.62 → EP.61`

`#001` now appears directly under the featured `#002`, matching the archive. Confirmed no legacy 2021–2023 episodes leak into the list (the 6-row cap still holds).

## Note for reviewer

Unrelated and left out of scope: the label is hardcoded `S.01 EP.{{ post.episode }}`, so the new season renders as "S.01 EP.1" rather than S.02. Cosmetic; happy to address separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)