### PR TITLE
fix(sync): use feed title verbatim when it already starts with #

### DIFF
--- a/scripts/sync-podcast.js
+++ b/scripts/sync-podcast.js
@@ -63,7 +63,12 @@ function padEpisode(num) {
 function cleanTitle(rawTitle, paddedEpisode) {
   let title = rawTitle.trim();
 
-  title = title.replace(/^#\s*\d{1,4}\s*[:\-–—]?\s*/i, "");
+  // If the feed already provides its own "#" prefix (e.g. "#065 …" or
+  // "#S2.03 …"), trust the feed title verbatim instead of re-deriving one.
+  if (title.startsWith("#")) {
+    return title;
+  }
+
   title = title.replace(/^\d{1,4}\s*[:\-–—]\s*/i, "");
 
   return `#${paddedEpisode} ${title}`.trim();


### PR DESCRIPTION
## Problem

`cleanTitle` in `scripts/sync-podcast.js` normalizes every episode title to a `#<padded-episode> <title>` form. To avoid double prefixes it first strips an existing leading marker — but the strip regex only matches a **numeric** `#NNN` prefix.

Season 2 feed titles use a season prefix `#S2.NN` (the character after `#` is `S`, not a digit), while the episode number lives in `<itunes:episode>`. The strip never matches, so the script stacks a second marker on top:

| Feed title | Generated (before) |
|---|---|
| `#S2.03 AI Transformation at miro …` | `#003 #S2.03 AI Transformation at miro …` |
| `#S2.02 Fable Ban - Now What?` | `#002 #S2.02 Fable Ban - Now What?` |

## Fix

Trust the feed title verbatim whenever it already begins with `#` (covers both legacy `#065 …` and new `#S2.NN …` formats). Titles without a `#` still get the canonical `#<episode>` fallback, so existing behavior is preserved for those.

Verified against the live RSS feed: generated titles now match the feed exactly for both formats.

## Note

The 3 already-published S2 posts (`001`, `002`, `003`) carried the doubled titles and the sync skips existing files, so they were back-filled separately and pushed directly to `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)