### PR TITLE
fix(home): correct season + zero-pad episode in accordion label

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -98,10 +98,12 @@ layout: default
        (Figma MCP unavailable this session — measured from the
        provided static export, not a live node inspection).
 
-       Label format "S.01 EP.XX - <title>": post front matter only
-       has a sequential `episode` number (no season field), so
-       season is hardcoded to "01" per the task instructions. The
-       "#0XX " prefix is stripped from post.title to get <title>.
+       Label format "S.NN EP.XX - <title>": season + within-season
+       episode are derived from the title marker. Season 2+ feeds use
+       a "#S<season>.<ep>" marker (e.g. "#S2.03"); the legacy season 1
+       used a plain "#<NNN>" marker, so it falls back to season 1 and
+       the front-matter `episode` number. The marker is stripped from
+       post.title to get <title>.
 
        <details>/<summary> provide native open/close semantics with
        no JS required; assets/js/accordion.js progressively enhances
@@ -118,9 +120,22 @@ layout: default
         {% assign title_parts = post.title | split: " " %}
         {% assign episode_title = title_parts | slice: 1, 99 | join: " " %}
 
+        {% comment %} Derive season + episode from the "#S<season>.<ep>" / "#<NNN>" marker. {% endcomment %}
+        {% assign marker = title_parts | first | remove: "#" %}
+        {% if marker contains "S" and marker contains "." %}
+          {% assign marker_bits = marker | remove_first: "S" | split: "." %}
+          {% assign season_label = marker_bits[0] %}
+          {% assign episode_label = marker_bits[1] | times: 1 %}
+        {% else %}
+          {% assign season_label = "1" %}
+          {% assign episode_label = post.episode %}
+        {% endif %}
+        {% if season_label.size == 1 %}{% assign season_label = season_label | prepend: "0" %}{% endif %}
+        {% if episode_label < 10 %}{% assign episode_label = episode_label | prepend: "0" %}{% endif %}
+
         <details class="accordion__item">
           <summary class="accordion__summary">
-            <span class="accordion__label">S.01 EP.{{ post.episode }} - {{ episode_title }}</span>
+            <span class="accordion__label">S.{{ season_label }} EP.{{ episode_label }} - {{ episode_title }}</span>
             <span class="accordion__icon" aria-hidden="true"></span>
           </summary>
           <div class="accordion__panel">


### PR DESCRIPTION
## Problem
The homepage accordion on bvc.fm hardcoded `S.01` for every episode. Season 2 restarted episode numbering (`#S2.NN` with `episode: 1/2/3`), so the Season 2 rows rendered with the **wrong season** — e.g. `S.01 EP.2 - Fable Ban…` instead of `S.02 EP.2`.

## Fix
Derive season + within-season episode from the title marker:
- `#S<season>.<ep>` (Season 2+) → parsed season and episode
- legacy `#<NNN>` → season 1 + front-matter `episode` number

Episode numbers are also zero-padded to two digits.

## Verified (local Jekyll build)
```
S.02 EP.02 - Fable Ban - Now What?
S.02 EP.01 - Reliable AI Agents…
S.01 EP.65 - Agentic Engineering…   (legacy unchanged)
```

Only `_layouts/home.html` changes; the sync script needs no change (it already passes `#S2.NN` titles through verbatim).

🤖 Generated with [Claude Code](https://claude.com/claude-code)