### PR TITLE
fix(home): align featured card title + extract episode-label partial

### DIFF
--- a/_includes/episode-label.html
+++ b/_includes/episode-label.html
@@ -1,0 +1,24 @@
+{%- comment -%}
+  Renders an episode label as "S.NN EP.NN - <title>".
+
+  Season + within-season episode are derived from the title marker:
+  "#S<season>.<ep>" for season 2+, falling back to season 1 and the
+  front-matter `episode` number for the legacy "#<NNN>" form. Both
+  numbers are zero-padded to two digits.
+
+  Usage: {% include episode-label.html post=latest %}
+{%- endcomment -%}
+{%- assign _parts = include.post.title | split: " " -%}
+{%- assign _episode_title = _parts | slice: 1, 99 | join: " " -%}
+{%- assign _marker = _parts | first | remove: "#" -%}
+{%- if _marker contains "S" and _marker contains "." -%}
+  {%- assign _bits = _marker | remove_first: "S" | split: "." -%}
+  {%- assign _season = _bits[0] -%}
+  {%- assign _episode = _bits[1] | times: 1 -%}
+{%- else -%}
+  {%- assign _season = "1" -%}
+  {%- assign _episode = include.post.episode -%}
+{%- endif -%}
+{%- if _season.size == 1 -%}{%- assign _season = _season | prepend: "0" -%}{%- endif -%}
+{%- if _episode < 10 -%}{%- assign _episode = _episode | prepend: "0" -%}{%- endif -%}
+S.{{ _season }} EP.{{ _episode }} - {{ _episode_title }}

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -67,8 +67,22 @@ layout: default
       </div>
 
       <div class="episode-card__body">
+        {% assign latest_parts = latest.title | split: " " %}
+        {% assign latest_episode_title = latest_parts | slice: 1, 99 | join: " " %}
+        {% comment %} Derive season + episode from the "#S<season>.<ep>" / "#<NNN>" marker (matches accordion). {% endcomment %}
+        {% assign latest_marker = latest_parts | first | remove: "#" %}
+        {% if latest_marker contains "S" and latest_marker contains "." %}
+          {% assign latest_marker_bits = latest_marker | remove_first: "S" | split: "." %}
+          {% assign latest_season_label = latest_marker_bits[0] %}
+          {% assign latest_episode_label = latest_marker_bits[1] | times: 1 %}
+        {% else %}
+          {% assign latest_season_label = "1" %}
+          {% assign latest_episode_label = latest.episode %}
+        {% endif %}
+        {% if latest_season_label.size == 1 %}{% assign latest_season_label = latest_season_label | prepend: "0" %}{% endif %}
+        {% if latest_episode_label < 10 %}{% assign latest_episode_label = latest_episode_label | prepend: "0" %}{% endif %}
         <h2 class="episode-card__title">
-          <a href="{{ latest.url | relative_url }}">{{ latest.title }}</a>
+          <a href="{{ latest.url | relative_url }}">S.{{ latest_season_label }} EP.{{ latest_episode_label }} - {{ latest_episode_title }}</a>
         </h2>
         <p class="episode-card__date">{{ latest.date | date: "%B %-d, %Y" }}</p>
         {% if latest.episode_url %}

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -67,22 +67,8 @@ layout: default
       </div>
 
       <div class="episode-card__body">
-        {% assign latest_parts = latest.title | split: " " %}
-        {% assign latest_episode_title = latest_parts | slice: 1, 99 | join: " " %}
-        {% comment %} Derive season + episode from the "#S<season>.<ep>" / "#<NNN>" marker (matches accordion). {% endcomment %}
-        {% assign latest_marker = latest_parts | first | remove: "#" %}
-        {% if latest_marker contains "S" and latest_marker contains "." %}
-          {% assign latest_marker_bits = latest_marker | remove_first: "S" | split: "." %}
-          {% assign latest_season_label = latest_marker_bits[0] %}
-          {% assign latest_episode_label = latest_marker_bits[1] | times: 1 %}
-        {% else %}
-          {% assign latest_season_label = "1" %}
-          {% assign latest_episode_label = latest.episode %}
-        {% endif %}
-        {% if latest_season_label.size == 1 %}{% assign latest_season_label = latest_season_label | prepend: "0" %}{% endif %}
-        {% if latest_episode_label < 10 %}{% assign latest_episode_label = latest_episode_label | prepend: "0" %}{% endif %}
         <h2 class="episode-card__title">
-          <a href="{{ latest.url | relative_url }}">S.{{ latest_season_label }} EP.{{ latest_episode_label }} - {{ latest_episode_title }}</a>
+          <a href="{{ latest.url | relative_url }}">{% include episode-label.html post=latest %}</a>
         </h2>
         <p class="episode-card__date">{{ latest.date | date: "%B %-d, %Y" }}</p>
         {% if latest.episode_url %}
@@ -112,12 +98,9 @@ layout: default
        (Figma MCP unavailable this session — measured from the
        provided static export, not a live node inspection).
 
-       Label format "S.NN EP.XX - <title>": season + within-season
-       episode are derived from the title marker. Season 2+ feeds use
-       a "#S<season>.<ep>" marker (e.g. "#S2.03"); the legacy season 1
-       used a plain "#<NNN>" marker, so it falls back to season 1 and
-       the front-matter `episode` number. The marker is stripped from
-       post.title to get <title>.
+       Label format "S.NN EP.NN - <title>" is rendered by the shared
+       _includes/episode-label.html partial (also used by the featured
+       card above) so both stay in sync.
 
        <details>/<summary> provide native open/close semantics with
        no JS required; assets/js/accordion.js progressively enhances
@@ -131,25 +114,9 @@ layout: default
         {% if accordion_count >= 6 %}{% break %}{% endif %}
         {% assign accordion_count = accordion_count | plus: 1 %}
 
-        {% assign title_parts = post.title | split: " " %}
-        {% assign episode_title = title_parts | slice: 1, 99 | join: " " %}
-
-        {% comment %} Derive season + episode from the "#S<season>.<ep>" / "#<NNN>" marker. {% endcomment %}
-        {% assign marker = title_parts | first | remove: "#" %}
-        {% if marker contains "S" and marker contains "." %}
-          {% assign marker_bits = marker | remove_first: "S" | split: "." %}
-          {% assign season_label = marker_bits[0] %}
-          {% assign episode_label = marker_bits[1] | times: 1 %}
-        {% else %}
-          {% assign season_label = "1" %}
-          {% assign episode_label = post.episode %}
-        {% endif %}
-        {% if season_label.size == 1 %}{% assign season_label = season_label | prepend: "0" %}{% endif %}
-        {% if episode_label < 10 %}{% assign episode_label = episode_label | prepend: "0" %}{% endif %}
-
         <details class="accordion__item">
           <summary class="accordion__summary">
-            <span class="accordion__label">S.{{ season_label }} EP.{{ episode_label }} - {{ episode_title }}</span>
+            <span class="accordion__label">{% include episode-label.html post=post %}</span>
             <span class="accordion__icon" aria-hidden="true"></span>
           </summary>
           <div class="accordion__panel">


### PR DESCRIPTION
Follow-up to #15, which merged before these two commits were pushed.

## Changes
1. **Format the featured (latest) episode title** to match the accordion. It previously printed the raw feed title (`#S2.03 AI Transformation…`) while the accordion used `S.NN EP.NN - <title>`.
2. **Extract the shared logic** into `_includes/episode-label.html`, included by both the featured card and the accordion so the label format stays in one place.

## Verified (local Jekyll build)
```
Featured:  S.02 EP.03 - AI Transformation at miro - Franziska Bruno Rivera
Accordion: S.02 EP.02 - Fable Ban - Now What?
           S.02 EP.01 - Reliable AI Agents…
           S.01 EP.65 - Agentic Engineering…   (legacy unchanged)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)