### PR TITLE
fix(archive): format episode titles with shared label partial

### DIFF
--- a/_layouts/archive.html
+++ b/_layouts/archive.html
@@ -37,7 +37,7 @@ layout: default
       {% endif %}
 
       <p class="home-episodes__item">
-        <a class="home-episodes__link" href="{{ post.url | relative_url }}">{{ post.title }}</a>
+        <a class="home-episodes__link" href="{{ post.url | relative_url }}">{% include episode-label.html post=post %}</a>
       </p>
     {% endfor %}
   </section>


### PR DESCRIPTION
Applies the shared `episode-label` partial to the **archive** list so entries read `S.NN EP.NN - <title>`, consistent with the homepage and detail page.

## Verified (local Jekyll build)
```
S.02 EP.03 - AI Transformation at miro - Franziska Bruno Rivera
S.02 EP.01 - Reliable AI Agents…
S.01 EP.65 - Agentic Engineering…
…
S.01 EP.01 - The Chief Technical Debt Owner   (oldest legacy entry)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)