### PR TITLE
Centralize and lowercase action-CTA strings

### DIFF
--- a/_data/ui.yml
+++ b/_data/ui.yml
@@ -1,0 +1,7 @@
+# UI copy — centralized action-CTA strings (single source of truth).
+# Lowercase, on-brand. Referenced as {{ site.data.ui.<key> }}.
+# Only action links live here; platform-follow buttons, headings, and
+# proper nouns are intentionally excluded.
+read_more: read more
+all_episodes: all episodes
+view_more_episodes: view more episodes

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -80,7 +80,7 @@ layout: default
         <p class="episode-card__desc">
           {{ latest.content | strip_html | truncatewords: 40 }}
         </p>
-        <a class="btn-cta" href="{{ latest.url | relative_url }}">Read more</a>
+        <a class="btn-cta" href="{{ latest.url | relative_url }}">{{ site.data.ui.read_more }}</a>
       </div>
 
     </article>
@@ -129,7 +129,7 @@ layout: default
             </div>
             <div class="accordion__content">
               <p class="accordion__desc">{{ post.content | strip_html | truncatewords: 50 }}</p>
-              <a class="accordion__readmore" href="{{ post.url | relative_url }}">Read more</a>
+              <a class="accordion__readmore" href="{{ post.url | relative_url }}">{{ site.data.ui.read_more }}</a>
               <div class="accordion__meta">
                 <div class="accordion__controls">
                   {% if post.episode_url %}
@@ -153,7 +153,7 @@ layout: default
 
       {% endfor %}
     </div>
-    <a class="btn-cta home-accordion__cta" href="{{ '/archive/' | relative_url }}">{view_more_episodes}</a>
+    <a class="btn-cta home-accordion__cta" href="{{ '/archive/' | relative_url }}">{{ site.data.ui.view_more_episodes }}</a>
   </section>
 
   <script src="{{ '/assets/js/accordion.js' | relative_url }}" defer></script>

--- a/_layouts/podcast_post.md
+++ b/_layouts/podcast_post.md
@@ -76,7 +76,7 @@ layout: default
       {% endif %}
     </div>
     <div class="post-nav__home">
-      <a class="btn-cta" href="{{ '/' | relative_url }}">All episodes</a>
+      <a class="btn-cta" href="{{ '/' | relative_url }}">{{ site.data.ui.all_episodes }}</a>
     </div>
     <div class="post-nav__newer">
       {% if page.next %}


### PR DESCRIPTION
## What changed

Centralizes the four action-CTA strings into a single source of truth (`_data/ui.yml`) and lowercases them for a consistent, casual voice.

- **New** `_data/ui.yml` — holds `read_more`, `all_episodes`, `view_more_episodes` (matches the existing `_data/*.yml` convention).
- **`_layouts/home.html`** — featured `read more` (l.83), accordion `read more` (l.132), and archive `view more episodes` (l.156) now source from `site.data.ui.*`.
- **`_layouts/podcast_post.md`** — `all episodes` link (l.79) sources `site.data.ui.all_episodes`.

## Why

CTA strings were hardcoded and inconsistently cased across layouts, and the archive CTA had a broken `{view_more_episodes}` single-brace placeholder that leaked to the rendered page. This makes the strings edit-once and fixes the leak.

## Reviewer notes

- The `{view_more_episodes}` placeholder leak is fixed — `grep -rn '{view_more_episodes}' _site/` returns nothing after a clean build.
- No scope creep: platform-follow buttons, headings, and proper nouns are untouched; the English/German mix is preserved.
- No test suite exists for this Jekyll site; verified via `jekyll build` (exits 0) plus grep checks across the homepage and all 24 episode pages.
- Tickets: PM #19, engineering #20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)